### PR TITLE
Add shebang for python executables

### DIFF
--- a/husmow.py
+++ b/husmow.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python
+
 import argparse
 import json
 import logging

--- a/status_logger.py
+++ b/status_logger.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python
+
 import argparse
 from datetime import datetime, timedelta
 from sched import scheduler


### PR DESCRIPTION
The scripts are made executables and can be called directly:
	./husmow.py status

The default Python interpreter is used to run the script,
when using this calling convention.

Signed-off-by: Thomas Monjalon <thomas@monjalon.net>